### PR TITLE
Onboarding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.jetbrainsCompose) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     kotlin("plugin.serialization") version "1.5.30"
+    id("com.google.gms.google-services") version "4.4.1" apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsCompose)
+    id("com.google.gms.google-services")
 }
 
 kotlin {
@@ -71,6 +72,8 @@ android {
         implementation(libs.kotlinx.coroutines.android)
         implementation("androidx.navigation:navigation-compose:2.7.7")
         implementation("io.coil-kt:coil-compose:2.6.0")
+        implementation(platform("com.google.firebase:firebase-bom:32.8.1"))
+        implementation("com.google.firebase:firebase-storage")
     }
 
     flavorDimensions += "flavor"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -12,9 +12,9 @@ kotlin {
             }
         }
     }
-    
+
     sourceSets {
-        
+
         androidMain.dependencies {
             implementation(libs.compose.ui.tooling.preview)
             implementation(libs.androidx.activity.compose)
@@ -69,6 +69,25 @@ android {
         implementation(libs.koin.core)
         implementation(libs.koin.android)
         implementation(libs.kotlinx.coroutines.android)
+        implementation("androidx.navigation:navigation-compose:2.7.7")
+    }
+
+    flavorDimensions += "flavor"
+    productFlavors {
+        create("dev") {
+            dimension = "flavor"
+            applicationIdSuffix = ".dev"
+            resValue("string", "app_name", "Blueprint-Dev")
+        }
+        create("qa") {
+            dimension = "flavor"
+            applicationIdSuffix = ".qa"
+            resValue("string", "app_name", "Blueprint-QA")
+        }
+        create("prod") {
+            dimension = "flavor"
+            resValue("string", "app_name", "Blueprint")
+        }
     }
 }
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -70,6 +70,7 @@ android {
         implementation(libs.koin.android)
         implementation(libs.kotlinx.coroutines.android)
         implementation("androidx.navigation:navigation-compose:2.7.7")
+        implementation("io.coil-kt:coil-compose:2.6.0")
     }
 
     flavorDimensions += "flavor"

--- a/composeApp/google-services.json
+++ b/composeApp/google-services.json
@@ -1,0 +1,48 @@
+{
+  "project_info": {
+    "project_number": "841859101834",
+    "project_id": "kmp-blueprint",
+    "storage_bucket": "kmp-blueprint.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:841859101834:android:36d3da60279e75ecffa973",
+        "android_client_info": {
+          "package_name": "com.thoughtworks.multiplatform.blueprint"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCO6PYOZ_2dL37ab5viOff0ZSU5bbbUSw0"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:841859101834:android:efd0bec23ed5b26bffa973",
+        "android_client_info": {
+          "package_name": "com.thoughtworks.multiplatform.blueprint.dev"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCO6PYOZ_2dL37ab5viOff0ZSU5bbbUSw0"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/BlueprintApplication.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/BlueprintApplication.kt
@@ -1,18 +1,19 @@
 package com.thoughtworks.multiplatform.blueprint
 
 import android.app.Application
+import com.thoughtworks.multiplatform.blueprint.feature.onboarding.di.onboardingModule
 import com.thoughtworks.multiplatform.blueprint.feature.splash.di.splashModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.GlobalContext.startKoin
 
-class BlueprintApplication : Application(){
-    
+class BlueprintApplication : Application() {
+
     override fun onCreate() {
         startKoin {
             androidLogger()
             androidContext(this@BlueprintApplication)
-            modules(splashModule)
+            modules(onboardingModule, splashModule)
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/MainActivity.kt
@@ -8,21 +8,28 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.thoughtworks.multiplatform.blueprint.feature.onboarding.presentation.OnboardingViewModel
 import com.thoughtworks.multiplatform.blueprint.feature.splash.presentation.SplashViewModel
 import com.thoughtworks.multiplatform.blueprint.feature.splash.ui.SplashScreen
+import com.thoughtworks.multiplatform.blueprint.platform.navigation.BlueprintNavigation
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MainActivity : ComponentActivity() {
 
     // Lazy inject ViewModel
     private val splashViewModel: SplashViewModel by viewModel()
+    private val onboardingViewModel: OnboardingViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContent {
-            val state = splashViewModel.state.collectAsState()
-            SplashScreen(modifier = Modifier.fillMaxSize(), state = state.value)
+            BlueprintNavigation(
+                splashViewModel = splashViewModel,
+                onboardingViewModel = onboardingViewModel
+            ) {
+                finish()
+            }
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/data/FirebaseClientOnboarding.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/data/FirebaseClientOnboarding.kt
@@ -1,0 +1,39 @@
+package com.thoughtworks.multiplatform.blueprint.feature.onboarding.data
+
+import com.google.firebase.storage.FirebaseStorage
+import com.google.firebase.storage.StorageReference
+import feature.onboarding.domain.ClientOnboarding
+import feature.onboarding.domain.Onboarding
+import feature.onboarding.domain.PageOnboarding
+import kotlinx.coroutines.tasks.await
+
+class FirebaseClientOnboarding(
+    private val storage: FirebaseStorage
+) : ClientOnboarding {
+
+    override suspend fun get(): Onboarding {
+        val storageRef = storage.reference
+        val imagesRef: StorageReference = storageRef.child("images/onboarding")
+        val pages = mutableListOf<PageOnboarding>()
+        try {
+            val listResult = imagesRef.listAll().await()
+            listResult.items.forEachIndexed { index, ref ->
+                val urlImage = ref.downloadUrl.await()
+                pages.add(
+                    PageOnboarding(
+                        "$index",
+                        ref.name,
+                        url = urlImage.toString()
+                    )
+                )
+            }
+            return Onboarding(
+                id = "firebase",
+                name = "Firebase Onboarding Storage",
+                pages = pages
+            )
+        } catch (e: Exception) {
+            return Onboarding.empty()
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/di/OnboardingModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/di/OnboardingModule.kt
@@ -1,6 +1,10 @@
 package com.thoughtworks.multiplatform.blueprint.feature.onboarding.di
 
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.storage.ktx.storage
+import com.google.firebase.storage.storage
 import com.russhwolf.settings.Settings
+import com.thoughtworks.multiplatform.blueprint.feature.onboarding.data.FirebaseClientOnboarding
 import com.thoughtworks.multiplatform.blueprint.feature.onboarding.presentation.OnboardingViewModel
 import feature.onboarding.data.DefaultClientOnboarding
 import feature.onboarding.data.RemoteClientOnboarding
@@ -29,7 +33,7 @@ val onboardingModule = module {
     }
 
     single<ClientOnboarding>(named("remote")) {
-        RemoteClientOnboarding()
+        FirebaseClientOnboarding(Firebase.storage)
     }
 
     single<ClientOnboarding>(named("default")) {

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/di/OnboardingModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/di/OnboardingModule.kt
@@ -1,0 +1,53 @@
+package com.thoughtworks.multiplatform.blueprint.feature.onboarding.di
+
+import com.russhwolf.settings.Settings
+import com.thoughtworks.multiplatform.blueprint.feature.onboarding.presentation.OnboardingViewModel
+import feature.onboarding.data.DefaultClientOnboarding
+import feature.onboarding.data.RemoteClientOnboarding
+import feature.onboarding.data.SharedOnboardingStore
+import feature.onboarding.domain.*
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+val onboardingModule = module {
+
+    viewModel {
+        OnboardingViewModel(get(), get())
+    }
+
+    single<Settings> {
+        Settings()
+    }
+
+    single<OnboardingStorage> {
+        SharedOnboardingStore(get())
+    }
+
+    single {
+        FinishOnboarding(get())
+    }
+
+    single<ClientOnboarding>(named("remote")) {
+        RemoteClientOnboarding()
+    }
+
+    single<ClientOnboarding>(named("default")) {
+        DefaultClientOnboarding()
+    }
+
+    single {
+        GetOnboarding(
+            remoteClient = get(qualifier = named("remote")),
+            defaultClient = get(qualifier = named("default"))
+        )
+    }
+
+    single {
+        FinishOnboarding(get())
+    }
+
+    single {
+        IsNeedToShowOnboarding(get())
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/presentation/OnboardingViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/presentation/OnboardingViewModel.kt
@@ -1,0 +1,49 @@
+package com.thoughtworks.multiplatform.blueprint.feature.onboarding.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import feature.onboarding.domain.FinishOnboarding
+import feature.onboarding.domain.GetOnboarding
+import feature.onboarding.domain.NotFoundOnboardingException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class OnboardingViewModel(
+    private val getOnboarding: GetOnboarding,
+    private val finishOnboarding: FinishOnboarding
+) : ViewModel() {
+    private val mutableState = MutableStateFlow(OnboardingViewState())
+    val state = mutableState.asStateFlow()
+
+    fun fetch() {
+        viewModelScope.launch {
+            try {
+                mutableState.update {
+                    it.copy(
+                        isLoading = false,
+                        onboarding = getOnboarding.invoke()
+                    )
+                }
+            } catch (exception: NotFoundOnboardingException) {
+                mutableState.update {
+                    it.copy(
+                        isLoading = false,
+                        onboarding = null,
+                        errorOnboarding = exception.message.orEmpty()
+                    )
+                }
+            }
+        }
+    }
+
+    fun finish() {
+        viewModelScope.launch {
+            finishOnboarding.invoke()
+            mutableState.update {
+                it.copy(isFinish = true)
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/presentation/OnboardingViewState.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/presentation/OnboardingViewState.kt
@@ -1,0 +1,10 @@
+package com.thoughtworks.multiplatform.blueprint.feature.onboarding.presentation
+
+import feature.onboarding.domain.Onboarding
+
+data class OnboardingViewState(
+    val isLoading: Boolean = true,
+    val onboarding: Onboarding? = null,
+    val isFinish: Boolean = false,
+    val errorOnboarding: String? = null
+)

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/ui/OnboardingScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/ui/OnboardingScreen.kt
@@ -1,0 +1,48 @@
+package com.thoughtworks.multiplatform.blueprint.feature.onboarding.ui
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.Button
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.thoughtworks.multiplatform.blueprint.feature.onboarding.presentation.OnboardingViewState
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun OnboardingScreen(
+    modifier: Modifier = Modifier.fillMaxSize(),
+    state: OnboardingViewState,
+    onFinish: () -> Unit
+) {
+    state.onboarding?.let { safeOnboarding ->
+        val pagerState = rememberPagerState(pageCount = {
+            safeOnboarding.pages.size
+        })
+        Scaffold(
+            content = { padding ->
+                HorizontalPager(
+                    modifier = Modifier.fillMaxSize().padding(padding),
+                    state = pagerState
+                ) { page ->
+                    Text(
+                        text = "Page: $page",
+                        modifier = Modifier
+                            .fillMaxSize()
+                    )
+                }
+            },
+            bottomBar = {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Button(onClick = onFinish) {
+                        Text("Finish")
+                    }
+                }
+            }
+        )
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/ui/OnboardingScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/ui/OnboardingScreen.kt
@@ -1,21 +1,20 @@
 package com.thoughtworks.multiplatform.blueprint.feature.onboarding.ui
 
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.*
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Button
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.thoughtworks.multiplatform.blueprint.feature.onboarding.presentation.OnboardingViewState
@@ -29,6 +28,12 @@ fun OnboardingScreen(
 ) {
     var isShowFinish by remember {
         mutableStateOf(false)
+    }
+    val isShowLoading = state.onboarding == null
+    if (isShowLoading) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
     }
     state.onboarding?.let { safeOnboarding ->
         val pagerState = rememberPagerState(pageCount = {
@@ -74,19 +79,33 @@ fun OnboardingScreen(
                 }
             },
             bottomBar = {
-                Box(modifier = Modifier.fillMaxWidth(), Alignment.Center) {
-                    if (isShowFinish) {
-                        AnimatedVisibility(visible = true) {
-                            Button(
-                                modifier = Modifier.height(40.dp),
-                                onClick = onFinish
-                            ) {
-                                Text("Finish")
-                            }
+                Box(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp), Alignment.Center) {
+                    val density = LocalDensity.current
+                    AnimatedVisibility(
+                        modifier = Modifier.height(40.dp),
+                        visible = isShowFinish,
+                        enter = slideInVertically {
+                            // Slide in from 40 dp from the top.
+                            with(density) { -40.dp.roundToPx() }
+                        } + expandVertically(
+                            // Expand from the top.
+                            expandFrom = Alignment.Top
+                        ) + fadeIn(
+                            // Fade in with the initial alpha of 0.3f.
+                            initialAlpha = 0.3f
+                        ),
+                        exit = slideOutVertically() + shrinkVertically() + fadeOut()
+                    ) {
+                        Button(
+                            modifier = Modifier.height(40.dp),
+                            onClick = onFinish
+                        ) {
+                            Text("Finish")
                         }
-                    } else {
-                        Spacer(Modifier.height(40.dp))
                     }
+                }
+                if (isShowFinish.not()) {
+                    Spacer(Modifier.height(56.dp))
                 }
             }
         )

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/ui/OnboardingScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/onboarding/ui/OnboardingScreen.kt
@@ -1,15 +1,23 @@
 package com.thoughtworks.multiplatform.blueprint.feature.onboarding.ui
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Button
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.thoughtworks.multiplatform.blueprint.feature.onboarding.presentation.OnboardingViewState
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -19,30 +27,73 @@ fun OnboardingScreen(
     state: OnboardingViewState,
     onFinish: () -> Unit
 ) {
+    var isShowFinish by remember {
+        mutableStateOf(false)
+    }
     state.onboarding?.let { safeOnboarding ->
         val pagerState = rememberPagerState(pageCount = {
             safeOnboarding.pages.size
         })
         Scaffold(
+            modifier = modifier,
             content = { padding ->
                 HorizontalPager(
                     modifier = Modifier.fillMaxSize().padding(padding),
                     state = pagerState
                 ) { page ->
-                    Text(
-                        text = "Page: $page",
-                        modifier = Modifier
-                            .fillMaxSize()
-                    )
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        AsyncImage(
+                            model = safeOnboarding.pages[page].url,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.size(400.dp)
+                                .clip(CircleShape)
+                                .background(Color.Black)
+                        )
+                    }
+                }
+                Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.BottomCenter) {
+                    Row(
+                        Modifier
+                            .wrapContentHeight()
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp),
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        repeat(pagerState.pageCount) { iteration ->
+                            val color = if (pagerState.currentPage == iteration) Color.DarkGray else Color.LightGray
+                            Box(
+                                modifier = Modifier
+                                    .padding(2.dp)
+                                    .clip(CircleShape)
+                                    .background(color)
+                                    .size(16.dp)
+                            )
+                        }
+                    }
                 }
             },
             bottomBar = {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    Button(onClick = onFinish) {
-                        Text("Finish")
+                Box(modifier = Modifier.fillMaxWidth(), Alignment.Center) {
+                    if (isShowFinish) {
+                        AnimatedVisibility(visible = true) {
+                            Button(
+                                modifier = Modifier.height(40.dp),
+                                onClick = onFinish
+                            ) {
+                                Text("Finish")
+                            }
+                        }
+                    } else {
+                        Spacer(Modifier.height(40.dp))
                     }
                 }
             }
         )
+        LaunchedEffect(pagerState) {
+            snapshotFlow { pagerState.currentPage }.collect { page ->
+                isShowFinish = (page == safeOnboarding.pages.size - 1)
+            }
+        }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/splash/di/SplashModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/splash/di/SplashModule.kt
@@ -24,6 +24,6 @@ val splashModule = module {
     }
     
     viewModel {
-        SplashViewModel(get())
+        SplashViewModel(get(), get())
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/splash/presentation/SplashViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/splash/presentation/SplashViewModel.kt
@@ -2,13 +2,15 @@ package com.thoughtworks.multiplatform.blueprint.feature.splash.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import feature.onboarding.domain.IsNeedToShowOnboarding
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import platform.version.domain.GetVersionStatus
 
 class SplashViewModel(
-    private val getVersionStatus: GetVersionStatus
+    private val getVersionStatus: GetVersionStatus,
+    private val isNeedToShowOnboarding: IsNeedToShowOnboarding
 ) : ViewModel() {
 
     private val mutableState = MutableStateFlow(SplashViewState())
@@ -20,7 +22,10 @@ class SplashViewModel(
 
     private fun fetch() {
         viewModelScope.launch {
-            mutableState.value = state.value.copy(versionDevice = getVersionStatus.invoke())
+            mutableState.value = state.value.copy(
+                versionDevice = getVersionStatus.invoke(),
+                isNeedToShowOnboarding = isNeedToShowOnboarding.invoke()
+            )
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/splash/presentation/SplashViewState.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/splash/presentation/SplashViewState.kt
@@ -1,7 +1,9 @@
 package com.thoughtworks.multiplatform.blueprint.feature.splash.presentation
 
+import feature.onboarding.domain.IsNeedToShowOnboarding
 import platform.version.domain.entity.VersionStatus
 
 data class SplashViewState(
-    val versionDevice: VersionStatus? = null
+    val versionDevice: VersionStatus? = null,
+    val isNeedToShowOnboarding: Boolean = false
 )

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/splash/ui/SplashScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/feature/splash/ui/SplashScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.thoughtworks.multiplatform.blueprint.feature.splash.presentation.SplashViewState
@@ -15,11 +16,18 @@ import platform.version.domain.entity.VersionStatus
 @Composable
 fun SplashScreen(
     modifier: Modifier,
-    state: SplashViewState
+    state: SplashViewState,
+    onNavigateToOnboarding: () -> Unit
 ) {
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         Column {
             state.versionDevice?.let { VersionDeviceMolecule(state = it) }
+        }
+    }
+
+    LaunchedEffect(state.isNeedToShowOnboarding) {
+        if(state.isNeedToShowOnboarding){
+            onNavigateToOnboarding()
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/platform/navigation/BlueprintNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/com/thoughtworks/multiplatform/blueprint/platform/navigation/BlueprintNavigation.kt
@@ -1,0 +1,46 @@
+package com.thoughtworks.multiplatform.blueprint.platform.navigation
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.thoughtworks.multiplatform.blueprint.feature.onboarding.presentation.OnboardingViewModel
+import com.thoughtworks.multiplatform.blueprint.feature.onboarding.ui.OnboardingScreen
+import com.thoughtworks.multiplatform.blueprint.feature.splash.presentation.SplashViewModel
+import com.thoughtworks.multiplatform.blueprint.feature.splash.ui.SplashScreen
+
+@Composable
+fun BlueprintNavigation(
+    splashViewModel: SplashViewModel,
+    onboardingViewModel: OnboardingViewModel,
+    onFinish: () -> Unit
+) {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = "splash") {
+        composable("splash") {
+            val state = splashViewModel.state.collectAsState()
+            SplashScreen(
+                modifier = Modifier.fillMaxSize(),
+                state = state.value,
+                onNavigateToOnboarding = {
+                    navController.navigate("onboarding")
+                }
+            )
+        }
+        composable("onboarding") {
+            LaunchedEffect(Unit) {
+                onboardingViewModel.fetch()
+            }
+            val state = onboardingViewModel.state.collectAsState()
+            OnboardingScreen(
+                state = state.value,
+                onFinish = onFinish
+            )
+        }
+        // Add more destinations similarly.
+    }
+} 

--- a/config/mockserver/mockoon/installation.txt
+++ b/config/mockserver/mockoon/installation.txt
@@ -1,0 +1,1 @@
+brew install mockoon

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 		A8182CEE2BCCBB1A0021F71A /* SplashScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8182CED2BCCBB1A0021F71A /* SplashScreen.swift */; };
 		A83CA3172BCE00CF0079A1CB /* IosDeviceVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83CA3162BCE00CF0079A1CB /* IosDeviceVersion.swift */; };
+		A8BE8D412BD89EA300A7B5FE /* OnboardingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BE8D402BD89EA300A7B5FE /* OnboardingScreen.swift */; };
+		A8BE8D442BD8A4C200A7B5FE /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = A8BE8D432BD8A4C200A7B5FE /* SDWebImageSwiftUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +28,7 @@
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A8182CED2BCCBB1A0021F71A /* SplashScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreen.swift; sourceTree = "<group>"; };
 		A83CA3162BCE00CF0079A1CB /* IosDeviceVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosDeviceVersion.swift; sourceTree = "<group>"; };
+		A8BE8D402BD89EA300A7B5FE /* OnboardingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingScreen.swift; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -34,6 +37,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A8BE8D442BD8A4C200A7B5FE /* SDWebImageSwiftUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -91,6 +95,7 @@
 		A8182CEA2BCCBA6C0021F71A /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				A8BE8D3E2BD89E7A00A7B5FE /* Onboarding */,
 				A8182CEB2BCCBA770021F71A /* Splash */,
 			);
 			name = Feature;
@@ -152,6 +157,22 @@
 			path = Molecule;
 			sourceTree = "<group>";
 		};
+		A8BE8D3E2BD89E7A00A7B5FE /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				A8BE8D3F2BD89E8900A7B5FE /* UI */,
+			);
+			name = Onboarding;
+			sourceTree = "<group>";
+		};
+		A8BE8D3F2BD89E8900A7B5FE /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				A8BE8D402BD89EA300A7B5FE /* OnboardingScreen.swift */,
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
 		AB1DB47929225F7C00F7AF9C /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
@@ -178,6 +199,7 @@
 			);
 			name = iosApp;
 			packageProductDependencies = (
+				A8BE8D432BD8A4C200A7B5FE /* SDWebImageSwiftUI */,
 			);
 			productName = iosApp;
 			productReference = 7555FF7B242A565900829871 /* iosApp.app */;
@@ -208,6 +230,7 @@
 			);
 			mainGroup = 7555FF72242A565900829871;
 			packageReferences = (
+				A8BE8D422BD8A4C200A7B5FE /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 			);
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
@@ -258,6 +281,7 @@
 			files = (
 				A8182CEE2BCCBB1A0021F71A /* SplashScreen.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
+				A8BE8D412BD89EA300A7B5FE /* OnboardingScreen.swift in Sources */,
 				A83CA3172BCE00CF0079A1CB /* IosDeviceVersion.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 				298B15E91212CC819028F28C /* VersionDeviceMolecule.swift in Sources */,
@@ -465,6 +489,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		A8BE8D422BD8A4C200A7B5FE /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SDWebImage/SDWebImageSwiftUI.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.0.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A8BE8D432BD8A4C200A7B5FE /* SDWebImageSwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A8BE8D422BD8A4C200A7B5FE /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */;
+			productName = SDWebImageSwiftUI;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 7555FF73242A565900829871 /* Project object */;
 }

--- a/iosApp/iosApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/iosApp/iosApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "4afe3317e0d15d2489436da7b7a4d73a0275f042e903c27b0a4897e00b1c9084",
+  "pins" : [
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "f6afa0132961d593f07970d84e2d8b588c29ea04",
+        "version" : "5.19.1"
+      }
+    },
+    {
+      "identity" : "sdwebimageswiftui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImageSwiftUI.git",
+      "state" : {
+        "revision" : "22423b017b99ab8ac44e29e6372f571f782af6e4",
+        "version" : "3.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/iosApp/iosApp/Splash/SplashScreen.swift
+++ b/iosApp/iosApp/Splash/SplashScreen.swift
@@ -32,7 +32,3 @@ struct SplashScreen: View {
         }
     }
 }
-
-#Preview {
-    SplashScreen()
-}

--- a/iosApp/iosApp/UI/OnboardingScreen.swift
+++ b/iosApp/iosApp/UI/OnboardingScreen.swift
@@ -1,0 +1,97 @@
+//
+//  OnboardingScreen.swift
+//  iosApp
+//
+//  Created by Harttin Andrés Arce Gajardo on 23-04-24.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import SwiftUI
+import SDWebImageSwiftUI
+import Shared
+
+struct OnboardingScreen: View {
+    
+    @State private var onboarding: Onboarding? = nil
+    @State private var currentPage = 0
+    let getOnboarding = GetOnboarding(
+        remoteClient: RemoteClientOnboarding(),
+        defaultClient: DefaultClientOnboarding()
+    )
+    
+    var body: some View {
+        VStack {
+            if let safeOnboarding = onboarding {
+                TabView(selection: $currentPage) {
+                    ForEach(0..<safeOnboarding.pages.count, id: \.self) { index in
+                        WebImage(url: URL(string: safeOnboarding.pages[index].url)) { image in
+                            image.resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 350, height: 350)
+                                .clipShape(Circle())
+                                .padding(16)
+                        } placeholder: {
+                            Rectangle().foregroundColor(.gray)
+                        }
+                        .onSuccess { image, data, cacheType in
+                            // Success
+                            // Note: Data exist only when queried from disk cache or network. Use `.queryMemoryData` if you really need data
+                        }
+                        .indicator(.activity) // Activity Indicator
+                        .transition(.fade(duration: 0.5)) // Fade Transition with duration
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
+                    .tabViewStyle(PageTabViewStyle(indexDisplayMode: .automatic))
+                }
+                .tabViewStyle(PageTabViewStyle(indexDisplayMode: .automatic))
+                
+                HStack {
+                    ForEach(0..<safeOnboarding.pages.count, id: \.self) { index in
+                        Circle()
+                            .fill(index == currentPage ? Color.black : Color.gray)
+                            .frame(width: 10, height: 10)
+                    }
+                }
+                .padding(.top, 8)
+                
+                if currentPage == safeOnboarding.pages.count - 1 {
+                    Button(
+                        action: {
+                            DispatchQueue.main.asyncAfter(deadline: .now()) {
+                                UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
+                            }
+                        }) {
+                            Text("Finalizar")
+                                .background(Color.blue)
+                                .foregroundColor(.white)
+                                .cornerRadius(8)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.regular)
+                        .frame(height: 40, alignment: .center)
+                    
+                } else {
+                    Spacer()
+                        .frame(height: 48)
+                }
+            }
+        }
+        .task {
+            do {
+                let asyncResult = try await getOnboarding.invoke()
+                DispatchQueue.main.async {
+                    self.onboarding = asyncResult
+                }
+            } catch {
+                print("Error: \(error)")
+            }
+        }
+    }
+}
+
+/*
+ #Preview {
+ OnboardingScreen()
+ }
+ */

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct iOSApp: App {
 	var body: some Scene {
 		WindowGroup {
-			SplashScreen()
+			OnboardingScreen()
 		}
 	}
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.DeprecatedTargetPresetApi
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -33,9 +34,15 @@ kotlin {
             implementation(libs.ktor.serialization.kotlinx.json)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.coroutines.core)
+            implementation("com.russhwolf:multiplatform-settings-serialization:1.1.1")
+            implementation("com.russhwolf:multiplatform-settings:1.1.1")
+            api("com.russhwolf:multiplatform-settings-no-arg:1.1.1")
+            implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.0-RC.2")
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1-Beta")
+
         }
         androidMain.dependencies {
             implementation(libs.ktor.client.okhttp)

--- a/shared/src/commonMain/kotlin/feature/onboarding/data/DefaultClientOnboarding.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/data/DefaultClientOnboarding.kt
@@ -1,0 +1,47 @@
+package feature.onboarding.data
+
+import feature.onboarding.domain.ClientOnboarding
+import feature.onboarding.domain.Onboarding
+import feature.onboarding.domain.PageOnboarding
+
+class DefaultClientOnboarding : ClientOnboarding {
+    override suspend fun get(): Onboarding {
+        return Onboarding(
+            id = "default",
+            name = "Onboarding",
+            getPages()
+        )
+    }
+
+    private fun getPages(): List<PageOnboarding> {
+        return listOf(
+            getFirstPage(),
+            getSecondPage(),
+            getFirstPage(),
+        )
+    }
+
+    private fun getFirstPage(): PageOnboarding {
+        return PageOnboarding(
+            id = "page1",
+            name = "Page one",
+            url = ""
+        )
+    }
+
+    private fun getSecondPage(): PageOnboarding {
+        return PageOnboarding(
+            id = "page2",
+            name = "Page two",
+            url = ""
+        )
+    }
+
+    private fun getThirdPage(): PageOnboarding {
+        return PageOnboarding(
+            id = "page3",
+            name = "Page third",
+            url = ""
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/feature/onboarding/data/DefaultClientOnboarding.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/data/DefaultClientOnboarding.kt
@@ -17,7 +17,7 @@ class DefaultClientOnboarding : ClientOnboarding {
         return listOf(
             getFirstPage(),
             getSecondPage(),
-            getFirstPage(),
+            getThirdPage(),
         )
     }
 
@@ -25,7 +25,7 @@ class DefaultClientOnboarding : ClientOnboarding {
         return PageOnboarding(
             id = "page1",
             name = "Page one",
-            url = ""
+            url = "https://developer.android.com/static/codelabs/jetpack-compose-animation/img/jetpack_compose_logo_with_rocket_856.png"
         )
     }
 
@@ -33,7 +33,7 @@ class DefaultClientOnboarding : ClientOnboarding {
         return PageOnboarding(
             id = "page2",
             name = "Page two",
-            url = ""
+            url = "https://cdn.hashnode.com/res/hashnode/image/upload/v1627633315818/vRdBa84mG.png"
         )
     }
 
@@ -41,7 +41,7 @@ class DefaultClientOnboarding : ClientOnboarding {
         return PageOnboarding(
             id = "page3",
             name = "Page third",
-            url = ""
+            url = "https://bignerdranch.com/wp-content/uploads/2021/05/swiftui-logo.jpg"
         )
     }
 }

--- a/shared/src/commonMain/kotlin/feature/onboarding/data/OnboargingStoreModel.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/data/OnboargingStoreModel.kt
@@ -1,0 +1,6 @@
+package feature.onboarding.data
+
+class OnboargingStoreModel(
+    val isFinish: Boolean,
+    val created: String
+)

--- a/shared/src/commonMain/kotlin/feature/onboarding/data/RemoteClientOnboarding.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/data/RemoteClientOnboarding.kt
@@ -1,0 +1,10 @@
+package feature.onboarding.data
+
+import feature.onboarding.domain.ClientOnboarding
+import feature.onboarding.domain.Onboarding
+
+class RemoteClientOnboarding : ClientOnboarding {
+    override suspend fun get(): Onboarding {
+        return Onboarding.empty()
+    }
+}

--- a/shared/src/commonMain/kotlin/feature/onboarding/data/SharedOnboardingStore.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/data/SharedOnboardingStore.kt
@@ -1,0 +1,23 @@
+package feature.onboarding.data
+
+import com.russhwolf.settings.Settings
+import feature.onboarding.domain.OnboardingStorage
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+class SharedOnboardingStore(
+    private val settings: Settings
+) : OnboardingStorage {
+    private val checkKey = "check"
+    private val checkDate = "date"
+    override suspend fun saveComplete() {
+        val now: Instant = Clock.System.now()
+        settings.putBoolean(checkKey, true)
+        settings.putString(checkDate, now.toString())
+    }
+
+    override suspend fun isFinish(): Boolean {
+        return settings.getBoolean(checkKey, false)
+    }
+
+}

--- a/shared/src/commonMain/kotlin/feature/onboarding/domain/ClientOnboarding.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/domain/ClientOnboarding.kt
@@ -1,0 +1,5 @@
+package feature.onboarding.domain
+
+interface ClientOnboarding {
+    suspend fun get(): Onboarding
+}

--- a/shared/src/commonMain/kotlin/feature/onboarding/domain/FinishOnboarding.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/domain/FinishOnboarding.kt
@@ -1,0 +1,11 @@
+package feature.onboarding.domain
+
+class FinishOnboarding(
+    private val database: OnboardingStorage
+) {
+    suspend fun invoke() {
+        if (database.isFinish().not()) {
+            database.saveComplete()
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/feature/onboarding/domain/GetOnboarding.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/domain/GetOnboarding.kt
@@ -1,0 +1,22 @@
+package feature.onboarding.domain
+
+class GetOnboarding(
+    private val remoteClient: ClientOnboarding,
+    private val defaultClient: ClientOnboarding
+) {
+    suspend fun invoke(): Onboarding {
+        val remote = remoteClient.get()
+        val default = defaultClient.get()
+        return if (remote.id.isNotEmpty()) {
+            remote
+        } else {
+            return if (default.id.isEmpty()) {
+                throw NotFoundOnboardingException(
+                    listOf(remoteClient, defaultClient)
+                )
+            } else {
+                default
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/feature/onboarding/domain/IsNeedToShowOnboarding.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/domain/IsNeedToShowOnboarding.kt
@@ -1,0 +1,7 @@
+package feature.onboarding.domain
+
+class IsNeedToShowOnboarding(
+    private val onboardingStorage: OnboardingStorage
+) {
+    suspend fun invoke() = onboardingStorage.isFinish().not()
+}

--- a/shared/src/commonMain/kotlin/feature/onboarding/domain/NotFoundOnboardingException.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/domain/NotFoundOnboardingException.kt
@@ -1,0 +1,9 @@
+package feature.onboarding.domain
+
+class NotFoundOnboardingException(
+    private val clients: List<ClientOnboarding>
+) : Exception(
+    "No information was found in any of the client: [" +
+            "$clients" +
+            "]"
+)

--- a/shared/src/commonMain/kotlin/feature/onboarding/domain/Onboarding.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/domain/Onboarding.kt
@@ -1,0 +1,11 @@
+package feature.onboarding.domain
+
+data class Onboarding(
+    val id: String,
+    val name: String,
+    val pages: List<PageOnboarding>
+) {
+    companion object {
+        fun empty() = Onboarding("", "", emptyList())
+    }
+}

--- a/shared/src/commonMain/kotlin/feature/onboarding/domain/OnboardingStorage.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/domain/OnboardingStorage.kt
@@ -1,0 +1,6 @@
+package feature.onboarding.domain
+
+interface OnboardingStorage {
+    suspend fun saveComplete()
+    suspend fun isFinish(): Boolean
+}

--- a/shared/src/commonMain/kotlin/feature/onboarding/domain/PageOnboarding.kt
+++ b/shared/src/commonMain/kotlin/feature/onboarding/domain/PageOnboarding.kt
@@ -1,0 +1,7 @@
+package feature.onboarding.domain
+
+data class PageOnboarding(
+    val id: String,
+    val name: String,
+    val url: String
+)

--- a/shared/src/commonTest/kotlin/feature/onboarding/domain/FactoryTest.kt
+++ b/shared/src/commonTest/kotlin/feature/onboarding/domain/FactoryTest.kt
@@ -1,0 +1,33 @@
+package feature.onboarding.domain
+
+object FactoryTest {
+    fun newFakeOnboarding(
+        id: String = "1",
+        name: String = "Fake Name",
+        pages: List<PageOnboarding> = emptyList(),
+        currentPage: Int = 0
+    ): Onboarding {
+        return Onboarding(
+            id,
+            name,
+            pages,
+            currentPage
+        )
+    }
+
+    fun newClientOnboarding(
+        id: String = "1",
+        name: String = "Fake Name",
+        pages: List<PageOnboarding> = emptyList(),
+        currentPage: Int = 0
+    ): ClientOnboarding {
+        return TestClientOnboarding(
+            newFakeOnboarding(
+                id,
+                name,
+                pages,
+                currentPage
+            )
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/feature/onboarding/domain/GetOnboardingTest.kt
+++ b/shared/src/commonTest/kotlin/feature/onboarding/domain/GetOnboardingTest.kt
@@ -1,0 +1,60 @@
+package feature.onboarding.domain
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class GetOnboardingTest {
+    private val remoteClient =
+        FactoryTest.newClientOnboarding("1")
+
+    private val defaultClient =
+        FactoryTest.newClientOnboarding("2")
+
+    @Test
+    fun givenACorrectRemoteAndDefaultClient_whenCallGetOnboardingUseCase_thenReturnRemoteOnboarding() = runTest {
+        // Given
+        val sut = GetOnboarding(
+            remoteClient,
+            defaultClient
+        )
+        // When
+        val onboarding = sut.invoke()
+        val remoteOnboarding = remoteClient.get()
+        // Then
+        assertEquals(onboarding.id, remoteOnboarding.id)
+    }
+
+    @Test
+    fun givenAEmptyOnboardingOnRemoteClientAndCorrectOnboardingOnDefaultClienet_WhenCallGetOnboardingUseCase_thenResponseDefaultOnboarding() =
+        runTest {
+            // Given
+            val incorrectClient = FactoryTest.newClientOnboarding(id = "")
+            val sut = GetOnboarding(
+                incorrectClient,
+                defaultClient
+            )
+            // When
+            val onboarding = sut.invoke()
+            val defaultOnboarding = defaultClient.get()
+            // Then
+            assertEquals(onboarding.id, defaultOnboarding.id)
+        }
+
+    @Test
+    fun givenAEmptyOnboardingOnRemoteClientAndEmptyOnboardingOnDefaultClienet_WhenCallGetOnboardingUseCase_thenThrowNotFoundOnboardingException() =
+        runTest {
+            // Given
+            val incorrectClient = FactoryTest.newClientOnboarding(id = "")
+            val sut = GetOnboarding(
+                incorrectClient,
+                incorrectClient
+            )
+            // Then
+            assertFailsWith<NotFoundOnboardingException> {
+                // When
+                val onboarding = sut.invoke()
+            }
+        }
+}

--- a/shared/src/commonTest/kotlin/feature/onboarding/domain/TestClientOnboarding.kt
+++ b/shared/src/commonTest/kotlin/feature/onboarding/domain/TestClientOnboarding.kt
@@ -1,0 +1,9 @@
+package feature.onboarding.domain
+
+class TestClientOnboarding(
+    private val onboarding: Onboarding
+) : ClientOnboarding {
+    override suspend fun get(): Onboarding {
+        return onboarding
+    }
+}

--- a/shared/src/commonTest/kotlin/platform/version/domain/IsMinVersionSupportedTest.kt
+++ b/shared/src/commonTest/kotlin/platform/version/domain/IsMinVersionSupportedTest.kt
@@ -1,7 +1,5 @@
-package platform.version
+package platform.version.domain
 
-import platform.version.domain.IsMinVersion
-import platform.version.domain.VersionFormatException
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse


### PR DESCRIPTION
## Describe your changes
Se agrega feature de Onborading.
Android: 
- Se crean los ambientes "Dev", "QA" y "Prod"
- Se integra Firebase al proyecto, soportando solo Dev y Prod, pendiente la configuración de Q.A.
- Se crea un cliente Firebase con toda la implementación de imágenes.
- Se crea un cliente por defecto para Android e IOS (Shared Module) que funciona sin internet.
- Se integra Coil Library para mostrar imágenes publicadas en un servidor.

iOS: 
- Se crea un cliente por defecto para Android e IOS (Shared Module) que funciona sin internet.
- Se integra la dependencia SDWebImageSwiftUI para mostrar imágenes publicadas en un servidor.

Shared Module:
- Se integra la biblioteca de Settings para almacenar cuando se muestra el onboarding. `com.russhwolf:multiplatform-settings`.
- Se integra la biblioteca de Time de Kotlin para obtener la hora que se registra la finalización del onboarding `org.jetbrains.kotlinx:kotlinx-datetime`.
- Se integra la biblioteca de Test para coroutinas y poder probar funcuones de extensión `org.jetbrains.kotlinx:kotlinx-coroutines-test`.

Deuda Tecnica:

iOS:
- Creación de Ambientes Dev, QA y Prod.
- Integración con Firebase.
- Firebase Storage Client para obtener las imagenes del Onboarding.

Android:
- Actualizar dependencias a catalog TOML.
- Integrar Firebase para ambiente Q.A.

## Evidencia
Firebase Store Images
![firebase-storage](https://github.com/vn55v8q/kmp-blueprint/assets/146869596/9d830b53-2705-4051-aa07-63fd5a757f22)
Android and Firebase Client
![android-onboarding-default-client-gif](https://github.com/vn55v8q/kmp-blueprint/assets/146869596/2bcbfd21-11a1-43a5-b176-d72c54e9e9e0)
iOS and Default Client
![ios-onboarding-default-client-gif](https://github.com/vn55v8q/kmp-blueprint/assets/146869596/cc116e28-03ac-4ea0-96d4-b1ffdfb722ee)





